### PR TITLE
Enable realtime pipeline execution and improve data fetching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,18 @@
+.git
+.DS_Store
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.pytest_cache/
+.mypy_cache/
+.venv/
+venv/
+build/
+CarbonCast.egg-info/
+curl_body.txt
+data_old (v2.1)/
+data_old(v3.1)/
+saved_first_tier_models/
+saved_second_tier_models/
+CI_forecast_data/

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+DOCKER_PLATFORM=linux/amd64
+EIA_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ src/CarbonCastAPI/__pycache__/
 src/CarbonCastAPI/CarbonCastAPI/__pycache__/
 src/CarbonCastAPI/CarbonCastRESTAPI/__pycache__/
 src/CarbonCastAPI/CarbonCastRESTAPI/migrations/__pycache__/
+.env.local
 src/CarbonCastAPI/db.sqlite3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,20 @@
-version: '3.9'
 services:
   web:
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
     build:
-      dockerfile: src/CarbonCastAPI/dockerfile
+      context: .
+      dockerfile: src/CarbonCastAPI/Dockerfile
     container_name: carbon_cast_api
+    working_dir: /CarbonCast
+    environment:
+      EIA_API_KEY: ${EIA_API_KEY:-}
+      MPLCONFIGDIR: /tmp/matplotlib
+      PYTHONPATH: /CarbonCast/src
+      XDG_CACHE_HOME: /tmp
+    command: >
+      sh -c "python src/CarbonCastAPI/manage.py migrate &&
+             python src/CarbonCastAPI/manage.py runserver 0.0.0.0:8000"
     ports:
-    - "8000:8000"
+      - "8000:8000"
     volumes:
-      - ./real_time/:/CarbonCast/real_time/
-      - ./src/CarbonCastAPI/db.sqlite3:/CarbonCast/src/CarbonCastAPI/db.sqlite3
+      - ./:/CarbonCast

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,6 @@ django-cors-headers
 qrcode==7.4.2
 pyotp==2.9.0
 entsoe-py==0.5.10
-xarray==23.7.0
+xarray==2023.7.0
 drf-yasg
 django-cors-headers

--- a/src/CarbonCastAPI/Dockerfile
+++ b/src/CarbonCastAPI/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.9-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV MPLCONFIGDIR=/tmp/matplotlib
+ENV XDG_CACHE_HOME=/tmp
+
+WORKDIR /CarbonCast
+
+COPY requirements.txt /tmp/requirements.txt
+COPY src/CarbonCastAPI/requirements.txt /tmp/requirements-api.txt
+
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r /tmp/requirements.txt \
+    && pip install --no-cache-dir -r /tmp/requirements-api.txt \
+    && mkdir -p /tmp/matplotlib
+
+COPY . /CarbonCast
+
+EXPOSE 8000

--- a/src/CarbonCastE2E.py
+++ b/src/CarbonCastE2E.py
@@ -26,7 +26,10 @@ import carbonIntensityCalculator as cicalc
 import os
 import sys
 import subprocess
+import shutil
+import re
 from datetime import datetime, timedelta
+from shutil import which
 import firstTierForecasts as ftf
 import secondTierForecasts as stf
 import cisoSolarWindForecastParser as cisosolwndfcst
@@ -44,39 +47,172 @@ US_REGIONS = ["AECI", "AZPS", "BPAT", "CISO", "DUK", "EPE", "ERCO", "FPL",
 
 EU_REGIONS = [] # add EU regions here
 
+def _get_real_time_region_dir(balAuth):
+    filedir = os.path.dirname(__file__)
+    return os.path.normpath(os.path.join(filedir, f"{REAL_TIME_FILE_DIR}{balAuth}"))
+
+def _get_real_time_root_dir():
+    filedir = os.path.dirname(__file__)
+    return os.path.normpath(os.path.join(filedir, REAL_TIME_FILE_DIR))
+
+def _get_real_time_weather_root_dir():
+    filedir = os.path.dirname(__file__)
+    return os.path.normpath(os.path.join(filedir, REAL_TIME_WEATHER_FILE_DIR))
+
+def _get_src_path(filename):
+    filedir = os.path.dirname(__file__)
+    return os.path.join(filedir, filename)
+
+def _get_real_time_csv_path(balAuth, date_str):
+    return os.path.join(_get_real_time_region_dir(balAuth), f"{balAuth}_{date_str}.csv")
+
+def _get_real_time_emissions_path(balAuth, date_str, emissions_type):
+    return os.path.join(
+        _get_real_time_region_dir(balAuth),
+        f"{balAuth}_{date_str}_{emissions_type}_emissions.csv",
+    )
+
+def _get_real_time_clean_path(balAuth, date_str):
+    return os.path.join(_get_real_time_region_dir(balAuth), f"{balAuth}_{date_str}_clean.csv")
+
+def _weather_param_dir(param):
+    filedir = os.path.dirname(__file__)
+    return os.path.normpath(
+        os.path.join(filedir, f"{REAL_TIME_WEATHER_FILE_DIR}{param.lower().replace('/', '_')}")
+    )
+
+def _exact_weather_files_exist(startDate):
+    yyyymmdd = startDate.replace("-", "")
+    params = ["UGRD/VGRD", "TMP/DPT", "DSWRF", "APCP"]
+    for param in params:
+        directory = _weather_param_dir(param)
+        for hour in range(3, 97, 3):
+            expected = os.path.join(
+                directory, f"gfs.t00z.pgrb2.0p25.{yyyymmdd}.f00{hour:02d}.grib2"
+            )
+            if not os.path.exists(expected):
+                return False
+    return True
+
+def runPreflightChecks(continent, baList, startDate):
+    print("Running realtime preflight checks")
+    issues = []
+    warnings = []
+
+    if continent == "US":
+        if os.getenv("EIA_API_KEY"):
+            print("Preflight: EIA_API_KEY configured")
+        else:
+            warnings.append(
+                "EIA_API_KEY is not configured. Live electricity fetch will fail and CarbonCast will rely on cached electricity data if available."
+            )
+
+    if which("wgrib2"):
+        print(f"Preflight: wgrib2 available at {which('wgrib2')}")
+    else:
+        issues.append("wgrib2 is not installed or not on PATH.")
+
+    if _exact_weather_files_exist(startDate):
+        print(f"Preflight: exact-date weather files already exist for {startDate}")
+    else:
+        warnings.append(
+            f"No exact-date weather files are present for {startDate}. A live NOMADS download is required for realtime forecasting."
+        )
+
+    for balAuth in baList:
+        region_dir = _get_real_time_region_dir(balAuth)
+        os.makedirs(region_dir, exist_ok=True)
+        os.makedirs(os.path.join(region_dir, "weather_data"), exist_ok=True)
+
+    if warnings:
+        for warning in warnings:
+            print(f"Preflight warning: {warning}")
+    if issues:
+        raise RuntimeError("Preflight failed: " + " ".join(issues))
+
+def _find_cached_electricity_file(balAuth, target_date):
+    region_dir = _get_real_time_region_dir(balAuth)
+    if not os.path.isdir(region_dir):
+        return None
+
+    pattern = re.compile(rf"^{re.escape(balAuth)}_(\d{{4}}-\d{{2}}-\d{{2}})\.csv$")
+    candidates = []
+    for filename in os.listdir(region_dir):
+        match = pattern.match(filename)
+        if not match:
+            continue
+        try:
+            candidate_date = datetime.strptime(match.group(1), "%Y-%m-%d")
+        except ValueError:
+            continue
+        candidates.append((abs((candidate_date - target_date).days), candidate_date, filename))
+
+    if not candidates:
+        return None
+
+    _, candidate_date, filename = min(candidates, key=lambda item: (item[0], item[1]))
+    return os.path.join(region_dir, filename), candidate_date.strftime("%Y-%m-%d")
+
+def _copy_cached_electricity_data(balAuth, startDate):
+    target_date = datetime.strptime(startDate, "%Y-%m-%d")
+    cached = _find_cached_electricity_file(balAuth, target_date)
+    if cached is None:
+        raise FileNotFoundError(f"No cached realtime electricity file found for {balAuth}.")
+
+    cached_path, cached_date = cached
+    target_path = _get_real_time_csv_path(balAuth, startDate)
+    if os.path.abspath(cached_path) != os.path.abspath(target_path):
+        shutil.copyfile(cached_path, target_path)
+    print(
+        f"Using cached electricity data for {balAuth}: "
+        f"{os.path.basename(cached_path)} -> {os.path.basename(target_path)}"
+    )
+    return target_path, cached_date
+
 def fetchElectricityData(continent, baList, startDate, creationTimeInUTC, version):
     # TODO: Change this to be downloaded only for the specific region
     print(f"Downloading EIA data on {startDate} for all regions in {continent}")
+    used_fallback = {}
     if (continent == "US"):
         for balAuth in baList:
-            # get electricity data
-            fetchedDataset = eiaParser.getELectricityProductionDataFromEIA(balAuth, startDate, numDays=1, DAY_JUMP=1)
-            filedir = os.path.dirname(__file__)
-            csvFile = os.path.normpath(os.path.join(filedir, f"{REAL_TIME_FILE_DIR}{balAuth}/{balAuth}_{str(startDate)}.csv"))
-            with open(csvFile, 'w') as f:
-                fetchedDataset.to_csv(f, index=False)
-            print("Electricity data fetched")
-            # clean electricity data
-            fetchedDataset = pd.read_csv(csvFile, header=0, parse_dates=["UTC time"], index_col=["UTC time"])
-            cleanedDataset = eiaParser.cleanElectricityProductionDataFromEIA(fetchedDataset, balAuth)
-            csvFileClean = REAL_TIME_FILE_DIR+balAuth+"/"+balAuth+"_"+str(startDate)+"_clean.csv"
-            cleanedDataset.to_csv(csvFileClean)
-            print("Electricity data cleaned")
+            csvFile = _get_real_time_csv_path(balAuth, startDate)
+            try:
+                fetchedDataset = eiaParser.getELectricityProductionDataFromEIA(
+                    balAuth, startDate, numDays=1, DAY_JUMP=1
+                )
+                with open(csvFile, 'w') as f:
+                    fetchedDataset.to_csv(f, index=False)
+                print("Electricity data fetched")
+                fetchedDataset = pd.read_csv(csvFile, header=0, parse_dates=["UTC time"], index_col=["UTC time"])
+                cleanedDataset = eiaParser.cleanElectricityProductionDataFromEIA(fetchedDataset, balAuth)
+                csvFileClean = _get_real_time_clean_path(balAuth, str(startDate))
+                cleanedDataset.to_csv(csvFileClean)
+                print("Electricity data cleaned")
 
-            # adjust source columns
-            cleanedDataset = pd.read_csv(csvFileClean, header=0, index_col=["UTC time"])
-            modifiedDataset = eiaParser.adjustColumns(cleanedDataset, balAuth)
-            modifiedDataset.insert(0, "creation_time (UTC)", creationTimeInUTC)
-            modifiedDataset.insert(1, "version", version)
-            modifiedDataset.to_csv(csvFile)
-            val = subprocess.call("rm "+csvFileClean, shell=True)
+                cleanedDataset = pd.read_csv(csvFileClean, header=0, index_col=["UTC time"])
+                modifiedDataset = eiaParser.adjustColumns(cleanedDataset, balAuth)
+                modifiedDataset.insert(0, "creation_time (UTC)", creationTimeInUTC)
+                modifiedDataset.insert(1, "version", version)
+                modifiedDataset.to_csv(csvFile)
+                val = subprocess.call("rm "+csvFileClean, shell=True)
+            except (eiaParser.EIADataError, pd.errors.ParserError, FileNotFoundError) as exc:
+                print(f"Live EIA fetch failed for {balAuth}: {exc}")
+                try:
+                    csvFile, cached_date = _copy_cached_electricity_data(balAuth, startDate)
+                    used_fallback[balAuth] = cached_date
+                except FileNotFoundError as fallback_exc:
+                    raise RuntimeError(
+                        f"Failed to fetch live EIA data for {balAuth} and no cached fallback was available."
+                    ) from fallback_exc
         print("Download complete")
+        if used_fallback:
+            print(f"Fallback electricity data used for: {used_fallback}")
 
         print("Calculating lifecycle and direct CI values")
         for balAuth in baList:
-            inFileName = REAL_TIME_FILE_DIR+balAuth+"/"+balAuth+"_"+str(startDate)+".csv"
-            lifecycleOutFileName = REAL_TIME_FILE_DIR+balAuth+"/"+balAuth+"_"+str(startDate)+"_lifecycle_emissions.csv"
-            directOutFileName = REAL_TIME_FILE_DIR+balAuth+"/"+balAuth+"_"+str(startDate)+"_direct_emissions.csv"
+            inFileName = _get_real_time_csv_path(balAuth, str(startDate))
+            lifecycleOutFileName = _get_real_time_emissions_path(balAuth, str(startDate), "lifecycle")
+            directOutFileName = _get_real_time_emissions_path(balAuth, str(startDate), "direct")
             cicalc.runProgram(region=balAuth, isLifecycle=True, isForecast=False, realTimeInFileName=inFileName, 
                               realTimeOutFileName=lifecycleOutFileName, forecastInFileName=None, 
                               forecastOutFileName=None, creationTimeInUTC=creationTimeInUTC, version=version)
@@ -92,14 +228,24 @@ def fetchWeatherData(continent, baList, startDate, creationTimeInUTC, version):
     print(f"Downloading weather data for {continent} on {startDate}")
         
     # fetch weather forecasts
-    getRealTimeWeatherData.getWeatherData(continent=continent, date=startDate)
+    try:
+        getRealTimeWeatherData.getWeatherData(continent=continent, date=startDate)
+    except getRealTimeWeatherData.WeatherDownloadError as exc:
+        raise RuntimeError(
+            f"Live weather data is unavailable for {startDate}. "
+            f"CarbonCast will not use weather files from a different date. {exc}"
+        ) from exc
     
     # aggregate weather forecasts
-    inFilePath = [REAL_TIME_WEATHER_FILE_DIR+"ugrd_vgrd/",
-        REAL_TIME_WEATHER_FILE_DIR+"tmp_dpt/",
-        REAL_TIME_WEATHER_FILE_DIR+"dswrf/",
-        REAL_TIME_WEATHER_FILE_DIR+"apcp/"]
-    outFilePath = REAL_TIME_FILE_DIR
+    weather_root = _get_real_time_weather_root_dir()
+    real_time_root = _get_real_time_root_dir()
+    inFilePath = [
+        os.path.join(weather_root, "ugrd_vgrd") + "/",
+        os.path.join(weather_root, "tmp_dpt") + "/",
+        os.path.join(weather_root, "dswrf") + "/",
+        os.path.join(weather_root, "apcp") + "/",
+    ]
+    outFilePath = real_time_root + "/"
     separateWeatherByRegion.startScript(continent=continent, regionList=baList, index=0, pid=os.getpid(), 
                                         inFilePath=inFilePath, outFilePath=outFilePath, 
                                         isRealTime=True, startDate=startDate) # index 0 is wind
@@ -116,7 +262,7 @@ def fetchWeatherData(continent, baList, startDate, creationTimeInUTC, version):
     # clean weather forecasts
     columnNames = ["forecast_avg_wind_speed_wMean", "forecast_avg_temperature_wMean", "forecast_avg_dewpoint_wMean", 
                     "forecast_avg_dswrf_wMean", "forecast_avg_precipitation_wMean"]
-    cleanWeatherData.startScript(regionList=baList, fileDir=REAL_TIME_FILE_DIR, 
+    cleanWeatherData.startScript(regionList=baList, fileDir=real_time_root + "/", 
                                     columnNames=columnNames, isRealTime=True, startDate=startDate,
                                     creationTimeInUTC=creationTimeInUTC, version=version)
     print("Generated weather forecasts")
@@ -135,32 +281,33 @@ def fetchSolarWindForecastsForCISO(filePath, startDate, creationTimeInUTC, versi
 def generateSourceProductionForecasts(baList, startDate, electricityDataDate, solWindFcstDataset, 
                                       creationTimeInUTC, version):
     # generate source production forecasts for each source & aggregate them in 1 file along with weather forecasts
-    return ftf.runFirstTierInRealTime(configFileName="firstTierConfig.json", regionList=baList, startDate=startDate,
+    return ftf.runFirstTierInRealTime(configFileName=_get_src_path("firstTierConfig.json"), regionList=baList, startDate=startDate,
                                       electricityDataDate=electricityDataDate, solWindFcstData=solWindFcstDataset,
-                                      realTimeFileDir=REAL_TIME_FILE_DIR, 
-                                      realTimeWeatherFileDir=REAL_TIME_FILE_DIR,
+                                      realTimeFileDir=_get_real_time_root_dir() + "/", 
+                                      realTimeWeatherFileDir=_get_real_time_root_dir() + "/",
                                       creationTimeInUTC=creationTimeInUTC, version=version)
 
 def generateCIForecasts(baList, startDate, electricityDataDate, aggregatedForecastFileName, 
                         creationTimeInUTC, version):
     # generate lifecycle & direct CI forecasts & write them to respective files
-    stf.runSecondTierInRealTime(configFileName="secondTierConfig.json", 
+    stf.runSecondTierInRealTime(configFileName=_get_src_path("secondTierConfig.json"), 
                                 regionList=baList, cefType="-l", startDate=startDate,
                                 electricityDataDate=electricityDataDate,
-                                realTimeFileDir=REAL_TIME_FILE_DIR, 
-                                realTimeWeatherFileDir=REAL_TIME_FILE_DIR,
+                                realTimeFileDir=_get_real_time_root_dir() + "/", 
+                                realTimeWeatherFileDir=_get_real_time_root_dir() + "/",
                                 realTimeForeCastFileName = aggregatedForecastFileName,
                                 creationTimeInUTC=creationTimeInUTC, version=version)
-    stf.runSecondTierInRealTime(configFileName="secondTierConfig.json", 
+    stf.runSecondTierInRealTime(configFileName=_get_src_path("secondTierConfig.json"), 
                                 regionList=baList, cefType="-d", startDate=startDate,
                                 electricityDataDate=electricityDataDate,                                                           
-                                realTimeFileDir=REAL_TIME_FILE_DIR, 
-                                realTimeWeatherFileDir=REAL_TIME_FILE_DIR,
+                                realTimeFileDir=_get_real_time_root_dir() + "/", 
+                                realTimeWeatherFileDir=_get_real_time_root_dir() + "/",
                                 realTimeForeCastFileName = aggregatedForecastFileName,
                                 creationTimeInUTC=creationTimeInUTC, version=version)
     return
 
 def startScript(continent, baList, startDate, creationTimeInUTC, version):
+    runPreflightChecks(continent, baList, startDate)
     startDateObj = datetime.strptime(startDate, "%Y-%m-%d")
     electricityDataDateObj = startDateObj - timedelta(days=1)
     electricityDataDate = electricityDataDateObj.strftime("%Y-%m-%d")

--- a/src/eiaParser.py
+++ b/src/eiaParser.py
@@ -5,9 +5,10 @@ from datetime import datetime, timedelta
 import time
 import sys
 import numpy as np
+from urllib.parse import urlparse, parse_qsl, urlencode, urlunparse
 
-# public key for EIA API
-EIA_API_KEY="CZdQsisRJzwOfqUWV3jiMPNEx3ZbHcuJ2VQus04i"
+class EIADataError(Exception):
+    pass
 
 # map EIA fuel types to source types
 EIA_SOURCE_MAP = {
@@ -33,6 +34,42 @@ EIA_BAL_AUTH_LIST = ["AECI", "AZPS", "BPAT", "CISO", "DUK", "EPE", "ERCOT", "FPC
                 "SWPP", "TIDC", "TVA", "WACM", "WALC"]
 
 # get production data by source type from EIA API
+def _get_eia_api_key():
+    api_key = os.getenv("EIA_API_KEY")
+    if not api_key:
+        raise EIADataError("Missing EIA_API_KEY environment variable.")
+    return api_key
+
+def _validate_eia_response(resp):
+    if resp.status_code != 200:
+        raise EIADataError(
+            f"EIA request failed with status {resp.status_code}: {resp.text}"
+        )
+
+    try:
+        payload = resp.json()
+    except ValueError as exc:
+        raise EIADataError("EIA response was not valid JSON.") from exc
+
+    if payload.get("error"):
+        raise EIADataError(f"EIA API returned an error payload: {payload['error']}")
+
+    response = payload.get("response")
+    if not response or "data" not in response:
+        raise EIADataError("EIA response did not contain response.data.")
+
+    return response["data"]
+
+def _sanitize_url(url):
+    parsed = urlparse(url)
+    query = []
+    for key, value in parse_qsl(parsed.query, keep_blank_values=True):
+        if key == "api_key":
+            query.append((key, "***"))
+        else:
+            query.append((key, value))
+    return urlunparse(parsed._replace(query=urlencode(query)))
+
 def getProductionDataBySourceTypeDataFromEIA(ba, curDate, curEndDate):
     print(ba)
     API_URL="https://api.eia.gov/v2/electricity/rto/fuel-type-data/data?api_key="
@@ -42,14 +79,13 @@ def getProductionDataBySourceTypeDataFromEIA(ba, curDate, curEndDate):
     startDate = curDate+"T00"
     endDate = curEndDate+"T23"
     print(startDate, endDate)
-    URL = API_URL+EIA_API_KEY+API_URL_SUFFIX.format(ba, startDate, endDate)
-    resp = requests.get(URL)
-    print(resp.url)
-    if (resp.status_code != 200):
-        print("Error! Code: ", resp.status_code)
-        print("Error! Message: ", resp.text)
-        print("Error! Reason: ", resp.reason)
-    responseData = resp.json()["response"]["data"]
+    URL = API_URL+_get_eia_api_key()+API_URL_SUFFIX.format(ba, startDate, endDate)
+    try:
+        resp = requests.get(URL, timeout=30)
+    except requests.RequestException as exc:
+        raise EIADataError(f"EIA request failed for {ba}: {exc}") from exc
+    print(_sanitize_url(resp.url))
+    responseData = _validate_eia_response(resp)
     return responseData
 
 # parse production data by source type from EIA API
@@ -130,7 +166,15 @@ def getELectricityProductionDataFromEIA(balAuth, startDate, numDays, DAY_JUMP):
         endDateObj = startDateObj + timedelta(days=DAY_JUMP-1)
         endDate = endDateObj.strftime("%Y-%m-%d")
         data = getProductionDataBySourceTypeDataFromEIA(balAuth, startDate, endDate)
-        if (days == 0): # assuming all data is correctly available for the first day at least
+        unique_periods = {entry["period"] for entry in data}
+        expected_hours = DAY_JUMP * 24
+        if len(unique_periods) < expected_hours:
+            raise EIADataError(
+                f"Incomplete EIA data for {balAuth} on {startDate}: "
+                f"expected {expected_hours} hourly periods, got {len(unique_periods)}."
+            )
+
+        if (days == 0):
             for electricitySourceData in data:
                 electricitySources.add(EIA_SOURCE_MAP[electricitySourceData["fueltype"]])
                 numSources = len(electricitySources)

--- a/src/firstTierForecasts.py
+++ b/src/firstTierForecasts.py
@@ -20,6 +20,7 @@ from keras.models import load_model
 import common
 import sys
 import json5 as json
+import os
 
 
 ############################# MACRO START #######################################
@@ -35,6 +36,15 @@ BUFFER_HOURS = None
 
 ############################# MACRO END #########################################
 
+def _flatten_prediction_output(predicted_data):
+    predicted_array = np.asarray(predicted_data, dtype=np.float64)
+    return predicted_array.reshape(-1)
+
+def _resolve_from_src(path):
+    if os.path.isabs(path):
+        return path
+    return os.path.normpath(os.path.join(os.path.dirname(__file__), path))
+
 def runFirstTier(configFileName):
     global TRAINING_WINDOW_HOURS
     global PREDICTION_WINDOW_HOURS
@@ -43,6 +53,7 @@ def runFirstTier(configFileName):
 
     firstTierConfig = {}
 
+    configFileName = _resolve_from_src(configFileName)
     with open(configFileName, "r") as configFile:
         firstTierConfig = json.load(configFile)
         # print(configurationData)
@@ -246,6 +257,7 @@ def runFirstTierInRealTime(configFileName, regionList, startDate, electricityDat
 
     firstTierConfig = {}
 
+    configFileName = _resolve_from_src(configFileName)
     with open(configFileName, "r") as configFile:
         firstTierConfig = json.load(configFile)
         # print(configurationData)
@@ -262,12 +274,14 @@ def runFirstTierInRealTime(configFileName, regionList, startDate, electricityDat
         sourceList = regionConfig["SOURCES"]
         sourceColList = regionConfig["SOURCE_COL"]
         weatherForecastInFileName = realTimeWeatherFileDir+region+"/"+region+"_weather_forecast_"+str(startDate)+".csv"
-        SAVED_MODEL_LOCATION = firstTierConfig["SAVED_MODEL_LOCATION"]+region+"/"
+        SAVED_MODEL_LOCATION = _resolve_from_src(firstTierConfig["SAVED_MODEL_LOCATION"]) + "/" + region + "/"
         aggregatedForecastFileNames[region] = realTimeFileDir+region+"/"+region+"_96hr_forecasts_"+str(startDate)+".csv"
         partialSourceProductionForecast = None
         sourceIdx = 0
         inFileName = realTimeFileDir+region+"/"+region+"_"+str(electricityDataDate)+".csv"
         outFileNamePrefix = realTimeFileDir+region+"/fuel_forecast/"+region+"_ANN"
+        os.makedirs(os.path.dirname(outFileNamePrefix), exist_ok=True)
+        os.makedirs(os.path.dirname(aggregatedForecastFileNames[region]), exist_ok=True)
         for source in sourceList:
             sourceCol = sourceColList[sourceIdx]+2 # +2 because we have now added creation time & version for real-time files
             partialSourceProductionForecastAvailable = True if solWindFcstData is not None else False # partial forecasts only for SOLAR and WIND
@@ -326,9 +340,9 @@ def runFirstTierInRealTime(configFileName, regionList, startDate, electricityDat
                         weatherData, partialSourceProductionForecast, isRenewableSource)
             print("***** Forecast done *****")
 
-            predictedData = predictedData.astype(np.float64)
+            predictedData = np.asarray(predictedData, dtype=np.float64)
             # print("PredictedData shape: ", predictedData.shape)
-            predicted = np.reshape(predictedData, predictedData.shape[0]*predictedData.shape[1])
+            predicted = _flatten_prediction_output(predictedData)
             # print("predicted.shape: ", predicted.shape)
             unscaledPredictedData = common.inverseDataScaling(predicted, 
                                                               ftMax[DEPENDENT_VARIABLE_COL], 
@@ -373,6 +387,7 @@ def aggregateDataAndGenerateForecastFile(firstTierConfig, sourceList, weatherFor
     # print(modifiedDataset.tail(2))
 
     # print("Writing weather+source production forecasts to file...")
+    os.makedirs(os.path.dirname(aggregatedForecastFileName), exist_ok=True)
     modifiedDataset.to_csv(aggregatedForecastFileName)
     # print("All forecasts written to a single file")
     return
@@ -681,9 +696,9 @@ def getUnscaledForecastsAndForecastAccuracy(testData, testDates, predictedData, 
     print("actual.shape: ", actual.shape)
     unscaledTestData = common.inverseDataScaling(actual, ftMax[DEPENDENT_VARIABLE_COL], 
                         ftMin[DEPENDENT_VARIABLE_COL])
-    predictedData = predictedData.astype(np.float64)
+    predictedData = np.asarray(predictedData, dtype=np.float64)
     print("PredictedData shape: ", predictedData.shape)
-    predicted = np.reshape(predictedData, predictedData.shape[0]*predictedData.shape[1])
+    predicted = _flatten_prediction_output(predictedData)
     print("predicted.shape: ", predicted.shape)
     unscaledPredictedData = common.inverseDataScaling(predicted, 
                 ftMax[DEPENDENT_VARIABLE_COL], ftMin[DEPENDENT_VARIABLE_COL])
@@ -719,6 +734,7 @@ def writeRealTimeSourceProductionForecastsToFile(formattedTestDates, unscaledPre
         data.append(row)
     print("Writing to ", outFileName, "...")
     fields = ["datetime", "creation_time (UTC)", "version", "avg_"+source.lower()+"_production_forecast"] # TODO:[DM] Change this & legacy code to UTC time later if required
+    os.makedirs(os.path.dirname(outFileName), exist_ok=True)
     with open(outFileName, "w") as csvfile: 
         csvwriter = csv.writer(csvfile)   
         csvwriter.writerow(fields) 

--- a/src/secondTierForecasts.py
+++ b/src/secondTierForecasts.py
@@ -15,8 +15,7 @@ import numpy as np
 import pandas as pd
 import pytz as pytz
 from keras.layers import Dense, Flatten, LSTM
-from keras.layers.convolutional import Conv1D, MaxPooling1D
-from keras.layers.core import Activation, Dropout
+from keras.layers import Activation, Conv1D, Dropout, MaxPooling1D
 from keras.models import Sequential
 import tensorflow as tf
 from keras.callbacks import EarlyStopping
@@ -25,6 +24,7 @@ from keras.models import load_model, save_model
 from keras.layers import RepeatVector
 
 import json5 as json
+import os
 
 import common
 import utility
@@ -46,6 +46,29 @@ SAVED_MODEL_LOCATION = None
 TOP_N_FEATURES = 0
 ############################# MACRO END #########################################
 
+def _resolve_from_src(path):
+    if os.path.isabs(path):
+        return path
+    return os.path.normpath(os.path.join(os.path.dirname(__file__), path))
+
+def _load_forecast_dataset(forecastInFileName):
+    forecastDataset = pd.read_csv(forecastInFileName, header=0, infer_datetime_format=True)
+    datetime_col = None
+    if "datetime" in forecastDataset.columns:
+        datetime_col = "datetime"
+    elif "UTC time" in forecastDataset.columns:
+        datetime_col = "UTC time"
+    else:
+        raise ValueError(
+            f"Forecast file {forecastInFileName} is missing a supported datetime column. "
+            "Expected 'datetime' or 'UTC time'."
+        )
+
+    forecastDataset[datetime_col] = pd.to_datetime(forecastDataset[datetime_col])
+    forecastDataset = forecastDataset.set_index(datetime_col)
+    forecastDataset.index.name = "datetime"
+    return forecastDataset
+
 def runSecondTier(configFileName, cefType, loadFromSavedModel):
     global TRAINING_WINDOW_HOURS
     global PREDICTION_WINDOW_HOURS
@@ -58,6 +81,7 @@ def runSecondTier(configFileName, cefType, loadFromSavedModel):
 
     secondTierConfig = {}
 
+    configFileName = _resolve_from_src(configFileName)
     with open(configFileName, "r") as configFile:
         secondTierConfig = json.load(configFile)
         # print(secondTierConfig)
@@ -76,9 +100,9 @@ def runSecondTier(configFileName, cefType, loadFromSavedModel):
     if (loadFromSavedModel is True):
         NUMBER_OF_EXPERIMENTS = 1
     if (cefType == "-l"):
-        SAVED_MODEL_LOCATION = secondTierConfig["LIFECYCLE_SAVED_MODEL_LOCATION"]
+        SAVED_MODEL_LOCATION = _resolve_from_src(secondTierConfig["LIFECYCLE_SAVED_MODEL_LOCATION"]) + "/"
     else:
-        SAVED_MODEL_LOCATION = secondTierConfig["DIRECT_SAVED_MODEL_LOCATION"]
+        SAVED_MODEL_LOCATION = _resolve_from_src(secondTierConfig["DIRECT_SAVED_MODEL_LOCATION"]) + "/"
     writeCIForecastsToFile = secondTierConfig["WRITE_CI_FORECASTS_TO_FILE"]
 
     for region in regionList:
@@ -268,6 +292,7 @@ def runSecondTierInRealTime(configFileName, regionList, cefType, startDate, elec
 
     secondTierConfig = {}
 
+    configFileName = _resolve_from_src(configFileName)
     with open(configFileName, "r") as configFile:
         secondTierConfig = json.load(configFile)
         # print(secondTierConfig)
@@ -279,9 +304,9 @@ def runSecondTierInRealTime(configFileName, regionList, cefType, startDate, elec
     TOP_N_FEATURES = secondTierConfig["TOP_N_FEATURES"]
 
     if (cefType == "-l"):
-        SAVED_MODEL_LOCATION = secondTierConfig["LIFECYCLE_SAVED_MODEL_LOCATION"]
+        SAVED_MODEL_LOCATION = _resolve_from_src(secondTierConfig["LIFECYCLE_SAVED_MODEL_LOCATION"]) + "/"
     else:
-        SAVED_MODEL_LOCATION = secondTierConfig["DIRECT_SAVED_MODEL_LOCATION"]
+        SAVED_MODEL_LOCATION = _resolve_from_src(secondTierConfig["DIRECT_SAVED_MODEL_LOCATION"]) + "/"
     writeCIForecastsToFile = secondTierConfig["WRITE_CI_FORECASTS_TO_FILE"]
 
     for region in regionList:
@@ -358,10 +383,7 @@ def initialize(inFileName, forecastInFileName, startCol):
     dateTime = dataset.index.values
 
     print(forecastInFileName)
-    # forecastDataset = pd.read_csv(forecastInFileName, header=0, infer_datetime_format=True, 
-    #                         parse_dates=['UTC time'], index_col=['UTC time']) # old data files
-    forecastDataset = pd.read_csv(forecastInFileName, header=0, infer_datetime_format=True, 
-                            parse_dates=['datetime'], index_col=['datetime']) # new data files in data
+    forecastDataset = _load_forecast_dataset(forecastInFileName)
     for i in range(startCol, len(dataset.columns.values)):
         col = dataset.columns.values[i]
         dataset[col] = dataset[col].astype(np.float64)
@@ -379,8 +401,7 @@ def initializeInRealTime(inFileName, forecastInFileName, startCol):
     dataset = pd.read_csv(inFileName, header=0, infer_datetime_format=True, 
                             parse_dates=['UTC time'], index_col=['UTC time'])
 
-    forecastDataset = pd.read_csv(forecastInFileName, header=0, infer_datetime_format=True, 
-                            parse_dates=['datetime'], index_col=['datetime'])
+    forecastDataset = _load_forecast_dataset(forecastInFileName)
     forecastDateTime = forecastDataset.index.values
     
     print("\nAdding features related to date & time...")

--- a/src/weather/getRealTimeWeatherData.py
+++ b/src/weather/getRealTimeWeatherData.py
@@ -7,6 +7,14 @@ import time
 import os
 
 url = "https://nomads.ncep.noaa.gov/cgi-bin/filter_gfs_0p25.pl"
+REQUEST_HEADERS = {
+    "User-Agent": "CarbonCast/1.0",
+    "Accept": "*/*",
+    "Connection": "close",
+}
+
+class WeatherDownloadError(Exception):
+    pass
 
 # continent = ["US", "EU"]
 
@@ -19,23 +27,81 @@ def buildUrl(date, param, level, continent, t):
     request_url = f"{url}?dir=/gfs.{date}/00/atmos&file=gfs.t00z.pgrb2.0p25.f0{t}&{'&'.join([f'var_{comp}=on' for comp in param.split('/')])}&lev_{level}=on&subregion=&toplat={boundingBox[continent]['nlat']}&leftlon={boundingBox[continent]['wlon']}&rightlon={boundingBox[continent]['elon']}&bottomlat={boundingBox[continent]['slat']}"
     return request_url
 
-def submitDataRequest(param, level, continent, year, month, day):
+def _get_output_dir(param):
     filedir = os.path.dirname(__file__)
+    output_dir = os.path.normpath(
+        os.path.join(filedir, f"../../real_time/weather_data/{param.lower().replace('/', '_')}")
+    )
+    os.makedirs(output_dir, exist_ok=True)
+    return output_dir
+
+def _get_output_path(param, year, month, day, t):
+    output_dir = _get_output_dir(param)
+    return os.path.join(
+        output_dir, f"gfs.t00z.pgrb2.0p25.{year}{month}{day}.f00{t}.grib2"
+    )
+
+def _all_expected_files_exist(param, year, month, day):
+    for i in range(3, 97, 3):
+        t = f"{i:02d}"
+        if not os.path.exists(_get_output_path(param, year, month, day, t)):
+            return False
+    return True
+
+def _validate_weather_response(response, request_url):
+    if response.status_code != 200:
+        raise WeatherDownloadError(
+            f"NOMADS request failed with status {response.status_code} for {request_url}"
+        )
+
+    content_type = response.headers.get("Content-Type", "").lower()
+    content_preview = response.content[:200].lstrip().lower()
+    if "text/html" in content_type or content_preview.startswith(b"<!doctype html") or content_preview.startswith(b"<html"):
+        raise WeatherDownloadError(
+            f"NOMADS returned HTML instead of GRIB2 content for {request_url}"
+        )
+
+    if not response.content:
+        raise WeatherDownloadError(f"NOMADS returned an empty response for {request_url}")
+
+def submitDataRequest(param, level, continent, year, month, day):
     t = "00"
     date = f"{year}{month}{day}"
-    # for i in range(1, 97): # uncomment this line & comment below line for hourly weather forecasts
-    for i in range(3, 97, 3): 
-        if i < 10:
-            t = "0" + str(i)
-        else:
-            t = str(i)
-        request_url = buildUrl(date, param, level, continent, t)
-        response = requests.get(request_url)
+    if _all_expected_files_exist(param, year, month, day):
+        print(f"Using existing exact-date weather files for {param} on {year}-{month}-{day}")
+        return
 
-        with open(os.path.normpath(os.path.join(filedir, f"../../real_time/weather_data/{param.lower().replace('/', '_')}/gfs.t00z.pgrb2.0p25.{year}{month}{day}.f00{t}.grib2")), 'wb+') as f:
-            f.write(response.content)
-        # print(f"Downloaded file: gfs.t00z.pgrb2.0p25.{year}{month}{day}.f00{t}.grib2")
-        time.sleep(1)
+    session = requests.Session()
+    session.headers.update(REQUEST_HEADERS)
+
+    # for i in range(1, 97): # uncomment this line & comment below line for hourly weather forecasts
+    try:
+        for i in range(3, 97, 3): 
+            if i < 10:
+                t = "0" + str(i)
+            else:
+                t = str(i)
+            request_url = buildUrl(date, param, level, continent, t)
+            try:
+                response = session.get(request_url, timeout=(15, 120), stream=True)
+            except requests.RequestException as exc:
+                raise WeatherDownloadError(
+                    f"NOMADS request failed for {request_url}: {exc}. "
+                    f"No exact-date cached weather files were available for {year}-{month}-{day}."
+                ) from exc
+
+            _validate_weather_response(response, request_url)
+
+            output_path = _get_output_path(param, year, month, day, t)
+            with open(output_path, 'wb+') as f:
+                for chunk in response.iter_content(chunk_size=1024 * 1024):
+                    if chunk:
+                        f.write(chunk)
+            response.close()
+            # print(f"Downloaded file: gfs.t00z.pgrb2.0p25.{year}{month}{day}.f00{t}.grib2")
+            time.sleep(1)
+    finally:
+        session.close()
 
 # date = 2023-05-21
 def getWeatherData(continent, date):

--- a/src/weather/separateWeatherByRegion.py
+++ b/src/weather/separateWeatherByRegion.py
@@ -390,6 +390,10 @@ def fetchWeatherDataByRegion(weatherVariable, fcstCol, pid, isRealTime, startDat
                     vdataset = None
                     udataset = None
                     for region in ISO_BOUNDING_BOX.keys():
+                        if region not in urow or region not in vrow:
+                            raise ValueError(
+                                f"Missing regional weather data for {region} while parsing {fileList[fileIdx-1]}"
+                            )
                         udataset = pd.DataFrame(urow[region], columns=HEADER)
                         vdataset = pd.DataFrame(vrow[region], columns=HEADER)
                         if (i==0):
@@ -448,6 +452,10 @@ def fetchWeatherDataByRegion(weatherVariable, fcstCol, pid, isRealTime, startDat
                                                         dataset["value"].iloc[line]])
                     # now we have region-wise datasets for this timestamp
                     for region in ISO_BOUNDING_BOX.keys():
+                        if region not in row:
+                            raise ValueError(
+                                f"Missing regional weather data for {region} while parsing {fileList[fileIdx-1]}"
+                            )
                         dataset = pd.DataFrame(row[region], columns=HEADER)
                         if (i==0):
                             latitude[region] = np.unique(dataset["latitude"].values)


### PR DESCRIPTION
Fixes #16

## Summary
- add Docker and runtime setup for local and containerized execution
- improve EIA and weather download handling for realtime runs
- fix path and config issues across realtime pipeline stages
- update first-tier and second-tier forecasting paths for realtime execution
- validate realtime runs for AECI and PJM with exact-date weather data

## Blockers Fixed
- Broken Docker setup: `docker-compose.yml` pointed at a missing Dockerfile, so I added a working Dockerfile and fixed Compose to build the app again.
- Docker dependency mismatch: the container only installed API requirements, so pipeline imports like `pandas` failed; I updated Docker to install both root and API requirements.
- Apple Silicon / cross-platform Docker breakage: old TensorFlow wheels were unreliable on native arm64, so Docker now defaults to configurable `linux/amd64` for safer Windows/Mac portability.
- Invalid dependency pin: `requirements.txt` had `xarray==23.7.0`, which does not exist; I corrected it to `2023.7.0` so installs succeed.
- Hardcoded / unsafe EIA access: `src/eiaParser.py` assumed happy-path API responses and leaked the key in logs; I moved the key to `EIA_API_KEY`, validated responses, and masked the key in printed URLs.
- EIA fetch crashing the whole pipeline: live electricity download failures used to abort everything; I added controlled EIA errors plus cached-electricity fallback in `src/CarbonCastE2E.py`.
- Relative path bugs in realtime execution: several pipeline stages assumed the process was launched from `src/`; I converted electricity, weather, first-tier, and second-tier paths to resolve from the repo/source location instead.
- Weather downloader writing invalid files: `src/weather/getRealTimeWeatherData.py` could save HTML/error pages as `.grib2`; I added HTTP status checks, empty/HTML rejection, and explicit weather download errors.
- Weather output directory missing: realtime weather download/parsing failed because target folders did not exist; I added directory creation before writes.
- Wrong-date weather fallback risk: the pipeline could have drifted toward stale weather reuse; I enforced exact-date-only weather reuse and clear failure messaging when same-date weather is unavailable.
- NOMADS requests hanging in Python: `curl` worked but `requests` could hang; I switched the downloader to sessions, streaming, explicit headers, and better timeouts so live weather fetch completes reliably.
- Missing-region weather crashes: `src/weather/separateWeatherByRegion.py` could fail with raw `KeyError`; I added clearer region-missing validation.
- No upfront runtime validation: users only discovered missing keys/tools mid-run; I added preflight checks in `src/CarbonCastE2E.py` for `EIA_API_KEY`, `wgrib2`, weather availability, and output directories.
- First-tier config path failure: realtime forecasting could not find `firstTierConfig.json`; I fixed first-tier config and model path resolution to work from the repo root.
- First-tier output directory failure: forecast CSV writes failed because `fuel_forecast/` did not exist; I made first-tier create realtime output directories before writing.
- First-tier model output shape bug: some regions like `PJM` returned prediction arrays in a different shape, causing reshape crashes; I normalized model outputs in `src/firstTierForecasts.py` with safe flattening.
- Second-tier config/model path failure: realtime CI forecasting could not find `secondTierConfig.json` or saved models reliably; I fixed second-tier config/model path resolution in `src/secondTierForecasts.py`.
- Second-tier saved-model path bug: lifecycle/direct model roots were being concatenated incorrectly; I fixed the saved-model base path so `lifecycle/<REGION>` and `direct/<REGION>` resolve correctly.
- Realtime forecast CSV timestamp mismatch: second-tier loading assumed one timestamp schema while realtime files used another; I added timestamp normalization so files with `UTC time` also load correctly.
- Outdated Keras imports: older import paths in `src/secondTierForecasts.py` could break on modern environments; I updated them to current `keras.layers` imports.

## Validation
- successful end-to-end realtime run for AECI on 2026-03-21
- successful end-to-end realtime run for AECI on 2026-03-22
- successful end-to-end realtime run for PJM on 2026-03-22
